### PR TITLE
Disable background change on resize

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,9 +75,9 @@ window.addEventListener("scroll", () => {
   }
 });
 
-window.addEventListener("resize", () => {
-  initBackground();
-});
+// window.addEventListener("resize", () => {
+//   initBackground();
+// });
 
 function initPage() {
   setActiveMenu(getActiveMenuId(window.scrollY));


### PR DESCRIPTION
Disable background change on resize because it got triggered on mobile browser when the top/bottom bar is showing/hiding